### PR TITLE
Remove change from commit f96a14b16d0d387d0c5bc4ac867121683ccce4b4

### DIFF
--- a/stats/services/avaxAccountService.ts
+++ b/stats/services/avaxAccountService.ts
@@ -414,8 +414,8 @@ async function singleVaultEvents(account, adpaterType, token, decimals) {
         account
     );
     let eventsPromise;
-    const isVersion1 = !adpaterType.includes('_v');
-    if (isVersion1 && !claimed && balance.isZero()) {
+
+    if (!claimed && balance.isZero()) {
         eventsPromise = [
             Promise.resolve([]),
             Promise.resolve([]),


### PR DESCRIPTION
Hey @lily-57blocks for some reason this change was causing an error for this wallet specifically 0xDC1a98d011aADf1F140d5925aa6ed3695600999E

Personal stats were not generating for AVAX and the error was in getting the block timestamp. If you can please investigate as I wasn't sure by your commit as to what issue you were fixing for 1.5/1.6 and I can't notice any difference in the personal stats.  

Please also see https://discord.com/channels/748111918698463312/832300720941564024/934048008310521886